### PR TITLE
Mat: Allow use of standard LHCb symbols

### DIFF
--- a/Proposal/ScientificProposal.tex
+++ b/Proposal/ScientificProposal.tex
@@ -31,6 +31,16 @@
 
 \renewcommand{\labelenumi}{\alph{enumi}.} % Make numbering in the enumerate environment by letter rather than number (e.g. section 6)
 
+% Standard LHCb symbol definitions
+\RequirePackage{xspace}
+\usepackage{hyperref}
+\usepackage[T1]{fontenc}
+\usepackage{ifthen} % for conditional statements
+\newboolean{uprightparticles}
+\setboolean{uprightparticles}{false} %True for upright particle symbols
+\input{lhcb-symbols-def}
+
+
 %\usepackage{times} % Uncomment to use the Times New Roman font
 
 %----------------------------------------------------------------------------------------

--- a/Proposal/lhcb-symbols-def.tex
+++ b/Proposal/lhcb-symbols-def.tex
@@ -1,0 +1,990 @@
+%%% $Id: lhcb-symbols-def.tex 56342 2014-06-20 08:48:41Z roldeman $
+%%% ======================================================================
+%%% Purpose: Standard LHCb aliases
+%%% Author: Originally Ulrik Egede, adapted by Tomasz Skwarnicki for templates,
+%%% rewritten by Chris Parkes
+%%% Maintainer : Ulrik Egede (2010 - 2012)
+%%% Maintainer : Rolf Oldeman (2012 - 2014)
+%%% =======================================================================
+
+%%% To use this file outside the normal LHCb document environment, the
+%%% following should be added in a preamble (before \begin{document}
+%%%
+%%%\usepackage{ifthen} 
+%%%\newboolean{uprightparticles}
+%%%\setboolean{uprightparticles}{false} %Set true for upright particle symbols
+%%% \usepackage{xspace} 
+%%% \usepackage{upgreek}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%
+%%% The following is to ensure that the template automatically can process
+%%% this file.
+%%%
+%%% Add comments with at least three %%% preceding.
+%%% Add new sections with one % preceding
+%%% Add new subsections with two %% preceding
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%
+% Experiments
+%%%%%%%%%%%%%
+\def\lhcb {\mbox{LHCb}\xspace}
+\def\atlas  {\mbox{ATLAS}\xspace}
+\def\cms    {\mbox{CMS}\xspace}
+\def\alice  {\mbox{ALICE}\xspace}
+\def\babar  {\mbox{BaBar}\xspace}
+\def\belle  {\mbox{Belle}\xspace}
+\def\cleo   {\mbox{CLEO}\xspace}
+\def\cdf    {\mbox{CDF}\xspace}
+\def\dzero  {\mbox{D0}\xspace}
+\def\aleph  {\mbox{ALEPH}\xspace}
+\def\delphi {\mbox{DELPHI}\xspace}
+\def\opal   {\mbox{OPAL}\xspace}
+\def\lthree {\mbox{L3}\xspace}
+\def\sld    {\mbox{SLD}\xspace}
+%%%\def\argus  {\mbox{ARGUS}\xspace}
+%%%\def\uaone  {\mbox{UA1}\xspace}
+%%%\def\uatwo  {\mbox{UA2}\xspace}
+%%%\def\ux85 {\mbox{UX85}\xspace}
+\def\cern {\mbox{CERN}\xspace}
+\def\lhc    {\mbox{LHC}\xspace}
+\def\lep    {\mbox{LEP}\xspace}
+\def\tevatron {Tevatron\xspace}
+
+%% LHCb sub-detectors and sub-systems
+
+%%%\def\pu     {PU\xspace}
+\def\velo   {VELO\xspace}
+\def\rich   {RICH\xspace}
+\def\richone {RICH1\xspace}
+\def\richtwo {RICH2\xspace}
+\def\ttracker {TT\xspace}
+\def\intr   {IT\xspace}
+\def\st     {ST\xspace}
+\def\ot     {OT\xspace}
+%%%\def\Tone   {T1\xspace}
+%%%\def\Ttwo   {T2\xspace}
+%%%\def\Tthree {T3\xspace}
+%%%\def\Mone   {M1\xspace}
+%%%\def\Mtwo   {M2\xspace}
+%%%\def\Mthree {M3\xspace}
+%%%\def\Mfour  {M4\xspace}
+%%%\def\Mfive  {M5\xspace}
+\def\spd    {SPD\xspace}
+\def\presh  {PS\xspace}
+\def\ecal   {ECAL\xspace}
+\def\hcal   {HCAL\xspace}
+%%%\def\bcm    {BCM\xspace}
+\def\MagUp {\mbox{\em Mag\kern -0.05em Up}\xspace}
+\def\MagDown {\mbox{\em MagDown}\xspace}
+
+%%%\def\ode    {ODE\xspace}
+%%%\def\daq    {DAQ\xspace}
+%%%\def\tfc    {TFC\xspace}
+%%%\def\ecs    {ECS\xspace}
+%%%\def\lone   {L0\xspace}
+%%%\def\hlt    {HLT\xspace}
+%%%\def\hltone {HLT1\xspace}
+%%%\def\hlttwo {HLT2\xspace}
+
+%%% Upright (not slanted) Particles
+
+\ifthenelse{\boolean{uprightparticles}}%
+{\def\Palpha      {\ensuremath{\upalpha}\xspace}
+ \def\Pbeta       {\ensuremath{\upbeta}\xspace}
+ \def\Pgamma      {\ensuremath{\upgamma}\xspace}                 
+ \def\Pdelta      {\ensuremath{\updelta}\xspace}                 
+ \def\Pepsilon    {\ensuremath{\upepsilon}\xspace}                 
+ \def\Pvarepsilon {\ensuremath{\upvarepsilon}\xspace}                 
+ \def\Pzeta       {\ensuremath{\upzeta}\xspace}                 
+ \def\Peta        {\ensuremath{\upeta}\xspace}                 
+ \def\Ptheta      {\ensuremath{\uptheta}\xspace}                 
+ \def\Pvartheta   {\ensuremath{\upvartheta}\xspace}                 
+ \def\Piota       {\ensuremath{\upiota}\xspace}                 
+ \def\Pkappa      {\ensuremath{\upkappa}\xspace}                 
+ \def\Plambda     {\ensuremath{\uplambda}\xspace}                 
+ \def\Pmu         {\ensuremath{\upmu}\xspace}                 
+ \def\Pnu         {\ensuremath{\upnu}\xspace}                 
+ \def\Pxi         {\ensuremath{\upxi}\xspace}                 
+ \def\Ppi         {\ensuremath{\uppi}\xspace}                 
+ \def\Pvarpi      {\ensuremath{\upvarpi}\xspace}                 
+ \def\Prho        {\ensuremath{\uprho}\xspace}                 
+ \def\Pvarrho     {\ensuremath{\upvarrho}\xspace}                 
+ \def\Ptau        {\ensuremath{\uptau}\xspace}                 
+ \def\Pupsilon    {\ensuremath{\upupsilon}\xspace}                 
+ \def\Pphi        {\ensuremath{\upphi}\xspace}                 
+ \def\Pvarphi     {\ensuremath{\upvarphi}\xspace}                 
+ \def\Pchi        {\ensuremath{\upchi}\xspace}                 
+ \def\Ppsi        {\ensuremath{\uppsi}\xspace}                 
+ \def\Pomega      {\ensuremath{\upomega}\xspace}                 
+
+ \def\PDelta      {\ensuremath{\Delta}\xspace}                 
+ \def\PXi      {\ensuremath{\Xi}\xspace}                 
+ \def\PLambda      {\ensuremath{\Lambda}\xspace}                 
+ \def\PSigma      {\ensuremath{\Sigma}\xspace}                 
+ \def\POmega      {\ensuremath{\Omega}\xspace}                 
+ \def\PUpsilon      {\ensuremath{\Upsilon}\xspace}                 
+ 
+ %\mathchardef\Deltares="7101
+ %\mathchardef\Xi="7104
+ %\mathchardef\Lambda="7103
+ %\mathchardef\Sigma="7106
+ %\mathchardef\Omega="710A
+
+
+ \def\PA      {\ensuremath{\mathrm{A}}\xspace}                 
+ \def\PB      {\ensuremath{\mathrm{B}}\xspace}                 
+ \def\PC      {\ensuremath{\mathrm{C}}\xspace}                 
+ \def\PD      {\ensuremath{\mathrm{D}}\xspace}                 
+ \def\PE      {\ensuremath{\mathrm{E}}\xspace}                 
+ \def\PF      {\ensuremath{\mathrm{F}}\xspace}                 
+ \def\PG      {\ensuremath{\mathrm{G}}\xspace}                 
+ \def\PH      {\ensuremath{\mathrm{H}}\xspace}                 
+ \def\PI      {\ensuremath{\mathrm{I}}\xspace}                 
+ \def\PJ      {\ensuremath{\mathrm{J}}\xspace}                 
+ \def\PK      {\ensuremath{\mathrm{K}}\xspace}                 
+ \def\PL      {\ensuremath{\mathrm{L}}\xspace}                 
+ \def\PM      {\ensuremath{\mathrm{M}}\xspace}                 
+ \def\PN      {\ensuremath{\mathrm{N}}\xspace}                 
+ \def\PO      {\ensuremath{\mathrm{O}}\xspace}                 
+ \def\PP      {\ensuremath{\mathrm{P}}\xspace}                 
+ \def\PQ      {\ensuremath{\mathrm{Q}}\xspace}                 
+ \def\PR      {\ensuremath{\mathrm{R}}\xspace}                 
+ \def\PS      {\ensuremath{\mathrm{S}}\xspace}                 
+ \def\PT      {\ensuremath{\mathrm{T}}\xspace}                 
+ \def\PU      {\ensuremath{\mathrm{U}}\xspace}                 
+ \def\PV      {\ensuremath{\mathrm{V}}\xspace}                 
+ \def\PW      {\ensuremath{\mathrm{W}}\xspace}                 
+ \def\PX      {\ensuremath{\mathrm{X}}\xspace}                 
+ \def\PY      {\ensuremath{\mathrm{Y}}\xspace}                 
+ \def\PZ      {\ensuremath{\mathrm{Z}}\xspace}                 
+ \def\Pa      {\ensuremath{\mathrm{a}}\xspace}                 
+ \def\Pb      {\ensuremath{\mathrm{b}}\xspace}                 
+ \def\Pc      {\ensuremath{\mathrm{c}}\xspace}                 
+ \def\Pd      {\ensuremath{\mathrm{d}}\xspace}                 
+ \def\Pe      {\ensuremath{\mathrm{e}}\xspace}                 
+ \def\Pf      {\ensuremath{\mathrm{f}}\xspace}                 
+ \def\Pg      {\ensuremath{\mathrm{g}}\xspace}                 
+ \def\Ph      {\ensuremath{\mathrm{h}}\xspace}                 
+ \def\Pi      {\ensuremath{\mathrm{i}}\xspace}                 
+ \def\Pj      {\ensuremath{\mathrm{j}}\xspace}                 
+ \def\Pk      {\ensuremath{\mathrm{k}}\xspace}                 
+ \def\Pl      {\ensuremath{\mathrm{l}}\xspace}                 
+ \def\Pm      {\ensuremath{\mathrm{m}}\xspace}                 
+ \def\Pn      {\ensuremath{\mathrm{n}}\xspace}                 
+ \def\Po      {\ensuremath{\mathrm{o}}\xspace}                 
+ \def\Pp      {\ensuremath{\mathrm{p}}\xspace}                 
+ \def\Pq      {\ensuremath{\mathrm{q}}\xspace}                 
+ \def\Pr      {\ensuremath{\mathrm{r}}\xspace}                 
+ \def\Ps      {\ensuremath{\mathrm{s}}\xspace}                 
+ \def\Pt      {\ensuremath{\mathrm{t}}\xspace}                 
+ \def\Pu      {\ensuremath{\mathrm{u}}\xspace}                 
+ \def\Pv      {\ensuremath{\mathrm{v}}\xspace}                 
+ \def\Pw      {\ensuremath{\mathrm{w}}\xspace}                 
+ \def\Px      {\ensuremath{\mathrm{x}}\xspace}                 
+ \def\Py      {\ensuremath{\mathrm{y}}\xspace}                 
+ \def\Pz      {\ensuremath{\mathrm{z}}\xspace}                 
+}
+{\def\Palpha      {\ensuremath{\alpha}\xspace}
+ \def\Pbeta       {\ensuremath{\beta}\xspace}
+ \def\Pgamma      {\ensuremath{\gamma}\xspace}                 
+ \def\Pdelta      {\ensuremath{\delta}\xspace}                 
+ \def\Pepsilon    {\ensuremath{\epsilon}\xspace}                 
+ \def\Pvarepsilon {\ensuremath{\varepsilon}\xspace}                 
+ \def\Pzeta       {\ensuremath{\zeta}\xspace}                 
+ \def\Peta        {\ensuremath{\eta}\xspace}                 
+ \def\Ptheta      {\ensuremath{\theta}\xspace}                 
+ \def\Pvartheta   {\ensuremath{\vartheta}\xspace}                 
+ \def\Piota       {\ensuremath{\iota}\xspace}                 
+ \def\Pkappa      {\ensuremath{\kappa}\xspace}                 
+ \def\Plambda     {\ensuremath{\lambda}\xspace}                 
+ \def\Pmu         {\ensuremath{\mu}\xspace}                 
+ \def\Pnu         {\ensuremath{\nu}\xspace}                 
+ \def\Pxi         {\ensuremath{\xi}\xspace}                 
+ \def\Ppi         {\ensuremath{\pi}\xspace}                 
+ \def\Pvarpi      {\ensuremath{\varpi}\xspace}                 
+ \def\Prho        {\ensuremath{\rho}\xspace}                 
+ \def\Pvarrho     {\ensuremath{\varrho}\xspace}                 
+ \def\Ptau        {\ensuremath{\tau}\xspace}                 
+ \def\Pupsilon    {\ensuremath{\upsilon}\xspace}                 
+ \def\Pphi        {\ensuremath{\phi}\xspace}                 
+ \def\Pvarphi     {\ensuremath{\varphi}\xspace}                 
+ \def\Pchi        {\ensuremath{\chi}\xspace}                 
+ \def\Ppsi        {\ensuremath{\psi}\xspace}                 
+ \def\Pomega      {\ensuremath{\omega}\xspace}                 
+ \mathchardef\PDelta="7101
+ \mathchardef\PXi="7104
+ \mathchardef\PLambda="7103
+ \mathchardef\PSigma="7106
+ \mathchardef\POmega="710A
+ \mathchardef\PUpsilon="7107
+ \def\PA      {\ensuremath{A}\xspace}                 
+ \def\PB      {\ensuremath{B}\xspace}                 
+ \def\PC      {\ensuremath{C}\xspace}                 
+ \def\PD      {\ensuremath{D}\xspace}                 
+ \def\PE      {\ensuremath{E}\xspace}                 
+ \def\PF      {\ensuremath{F}\xspace}                 
+ \def\PG      {\ensuremath{G}\xspace}                 
+ \def\PH      {\ensuremath{H}\xspace}                 
+ \def\PI      {\ensuremath{I}\xspace}                 
+ \def\PJ      {\ensuremath{J}\xspace}                 
+ \def\PK      {\ensuremath{K}\xspace}                 
+ \def\PL      {\ensuremath{L}\xspace}                 
+ \def\PM      {\ensuremath{M}\xspace}                 
+ \def\PN      {\ensuremath{N}\xspace}                 
+ \def\PO      {\ensuremath{O}\xspace}                 
+ \def\PP      {\ensuremath{P}\xspace}                 
+ \def\PQ      {\ensuremath{Q}\xspace}                 
+ \def\PR      {\ensuremath{R}\xspace}                 
+ \def\PS      {\ensuremath{S}\xspace}                 
+ \def\PT      {\ensuremath{T}\xspace}                 
+ \def\PU      {\ensuremath{U}\xspace}                 
+ \def\PV      {\ensuremath{V}\xspace}                 
+ \def\PW      {\ensuremath{W}\xspace}                 
+ \def\PX      {\ensuremath{X}\xspace}                 
+ \def\PY      {\ensuremath{Y}\xspace}                 
+ \def\PZ      {\ensuremath{Z}\xspace}                 
+ \def\Pa      {\ensuremath{a}\xspace}                 
+ \def\Pb      {\ensuremath{b}\xspace}                 
+ \def\Pc      {\ensuremath{c}\xspace}                 
+ \def\Pd      {\ensuremath{d}\xspace}                 
+ \def\Pe      {\ensuremath{e}\xspace}                 
+ \def\Pf      {\ensuremath{f}\xspace}                 
+ \def\Pg      {\ensuremath{g}\xspace}                 
+ \def\Ph      {\ensuremath{h}\xspace}                 
+ \def\Pi      {\ensuremath{i}\xspace}                 
+ \def\Pj      {\ensuremath{j}\xspace}                 
+ \def\Pk      {\ensuremath{k}\xspace}                 
+ \def\Pl      {\ensuremath{l}\xspace}                 
+ \def\Pm      {\ensuremath{m}\xspace}                 
+ \def\Pn      {\ensuremath{n}\xspace}                 
+ \def\Po      {\ensuremath{o}\xspace}                 
+ \def\Pp      {\ensuremath{p}\xspace}                 
+ \def\Pq      {\ensuremath{q}\xspace}                 
+ \def\Pr      {\ensuremath{r}\xspace}                 
+ \def\Ps      {\ensuremath{s}\xspace}                 
+ \def\Pt      {\ensuremath{t}\xspace}                 
+ \def\Pu      {\ensuremath{u}\xspace}                 
+ \def\Pv      {\ensuremath{v}\xspace}                 
+ \def\Pw      {\ensuremath{w}\xspace}                 
+ \def\Px      {\ensuremath{x}\xspace}                 
+ \def\Py      {\ensuremath{y}\xspace}                 
+ \def\Pz      {\ensuremath{z}\xspace}                 
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Particles
+\makeatletter
+\ifcase \@ptsize \relax% 10pt
+  \newcommand{\miniscule}{\@setfontsize\miniscule{4}{5}}% \tiny: 5/6
+\or% 11pt
+  \newcommand{\miniscule}{\@setfontsize\miniscule{5}{6}}% \tiny: 6/7
+\or% 12pt
+  \newcommand{\miniscule}{\@setfontsize\miniscule{5}{6}}% \tiny: 6/7
+\fi
+\makeatother
+
+
+\DeclareRobustCommand{\optbar}[1]{\shortstack{{\miniscule (\rule[.5ex]{1.25em}{.18mm})}
+  \\ [-.7ex] $#1$}}
+
+
+%% Leptons
+
+\let\emi\en
+\def\electron   {{\ensuremath{\Pe}}\xspace}
+\def\en         {{\ensuremath{\Pe^-}}\xspace}   % electron negative (\em is taken)
+\def\ep         {{\ensuremath{\Pe^+}}\xspace}
+\def\epm        {{\ensuremath{\Pe^\pm}}\xspace} 
+\def\epem       {{\ensuremath{\Pe^+\Pe^-}}\xspace}
+%%%\def\ee         {\ensuremath{\Pe^-\Pe^-}\xspace}
+
+\def\muon       {{\ensuremath{\Pmu}}\xspace}
+\def\mup        {{\ensuremath{\Pmu^+}}\xspace}
+\def\mun        {{\ensuremath{\Pmu^-}}\xspace} % muon negative (\mum is taken)
+\def\mumu       {{\ensuremath{\Pmu^+\Pmu^-}}\xspace}
+
+\def\tauon      {{\ensuremath{\Ptau}}\xspace}
+\def\taup       {{\ensuremath{\Ptau^+}}\xspace}
+\def\taum       {{\ensuremath{\Ptau^-}}\xspace}
+\def\tautau     {{\ensuremath{\Ptau^+\Ptau^-}}\xspace}
+
+\def\lepton     {{\ensuremath{\ell}}\xspace}
+\def\ellm       {{\ensuremath{\ell^-}}\xspace}
+\def\ellp       {{\ensuremath{\ell^+}}\xspace}
+%%%\def\ellell     {\ensuremath{\ell^+ \ell^-}\xspace}
+
+\def\neu        {{\ensuremath{\Pnu}}\xspace}
+\def\neub       {{\ensuremath{\overline{\Pnu}}}\xspace}
+%%%\def\nuenueb    {\ensuremath{\neu\neub}\xspace}
+\def\neue       {{\ensuremath{\neu_e}}\xspace}
+\def\neueb      {{\ensuremath{\neub_e}}\xspace}
+%%%\def\neueneueb  {\ensuremath{\neue\neueb}\xspace}
+\def\neum       {{\ensuremath{\neu_\mu}}\xspace}
+\def\neumb      {{\ensuremath{\neub_\mu}}\xspace}
+%%%\def\neumneumb  {\ensuremath{\neum\neumb}\xspace}
+\def\neut       {{\ensuremath{\neu_\tau}}\xspace}
+\def\neutb      {{\ensuremath{\neub_\tau}}\xspace}
+%%%\def\neutneutb  {\ensuremath{\neut\neutb}\xspace}
+\def\neul       {{\ensuremath{\neu_\ell}}\xspace}
+\def\neulb      {{\ensuremath{\neub_\ell}}\xspace}
+%%%\def\neulneulb  {\ensuremath{\neul\neulb}\xspace}
+
+%% Gauge bosons and scalars
+
+\def\g      {{\ensuremath{\Pgamma}}\xspace}
+\def\H      {{\ensuremath{\PH^0}}\xspace}
+\def\Hp     {{\ensuremath{\PH^+}}\xspace}
+\def\Hm     {{\ensuremath{\PH^-}}\xspace}
+\def\Hpm    {{\ensuremath{\PH^\pm}}\xspace}
+\def\W      {{\ensuremath{\PW}}\xspace}
+\def\Wp     {{\ensuremath{\PW^+}}\xspace}
+\def\Wm     {{\ensuremath{\PW^-}}\xspace}
+\def\Wpm    {{\ensuremath{\PW^\pm}}\xspace}
+\def\Z      {{\ensuremath{\PZ}}\xspace}
+
+%% Quarks
+
+\def\quark     {{\ensuremath{\Pq}}\xspace}
+\def\quarkbar  {{\ensuremath{\overline \quark}}\xspace}
+\def\qqbar     {{\ensuremath{\quark\quarkbar}}\xspace}
+\def\uquark    {{\ensuremath{\Pu}}\xspace}
+\def\uquarkbar {{\ensuremath{\overline \uquark}}\xspace}
+\def\uubar     {{\ensuremath{\uquark\uquarkbar}}\xspace}
+\def\dquark    {{\ensuremath{\Pd}}\xspace}
+\def\dquarkbar {{\ensuremath{\overline \dquark}}\xspace}
+\def\ddbar     {{\ensuremath{\dquark\dquarkbar}}\xspace}
+\def\squark    {{\ensuremath{\Ps}}\xspace}
+\def\squarkbar {{\ensuremath{\overline \squark}}\xspace}
+\def\ssbar     {{\ensuremath{\squark\squarkbar}}\xspace}
+\def\cquark    {{\ensuremath{\Pc}}\xspace}
+\def\cquarkbar {{\ensuremath{\overline \cquark}}\xspace}
+\def\ccbar     {{\ensuremath{\cquark\cquarkbar}}\xspace}
+\def\bquark    {{\ensuremath{\Pb}}\xspace}
+\def\bquarkbar {{\ensuremath{\overline \bquark}}\xspace}
+\def\bbbar     {{\ensuremath{\bquark\bquarkbar}}\xspace}
+\def\tquark    {{\ensuremath{\Pt}}\xspace}
+\def\tquarkbar {{\ensuremath{\overline \tquark}}\xspace}
+\def\ttbar     {{\ensuremath{\tquark\tquarkbar}}\xspace}
+
+%% Light mesons
+
+\def\hadron {{\ensuremath{\Ph}}\xspace}
+\def\pion   {{\ensuremath{\Ppi}}\xspace}
+\def\piz    {{\ensuremath{\pion^0}}\xspace}
+\def\pizs   {{\ensuremath{\pion^0\mbox\,\rm{s}}}\xspace}
+\def\pip    {{\ensuremath{\pion^+}}\xspace}
+\def\pim    {{\ensuremath{\pion^-}}\xspace}
+\def\pipm   {{\ensuremath{\pion^\pm}}\xspace}
+\def\pimp   {{\ensuremath{\pion^\mp}}\xspace}
+
+\def\rhomeson {{\ensuremath{\Prho}}\xspace}
+\def\rhoz     {{\ensuremath{\rhomeson^0}}\xspace}
+\def\rhop     {{\ensuremath{\rhomeson^+}}\xspace}
+\def\rhom     {{\ensuremath{\rhomeson^-}}\xspace}
+\def\rhopm    {{\ensuremath{\rhomeson^\pm}}\xspace}
+\def\rhomp    {{\ensuremath{\rhomeson^\mp}}\xspace}
+
+\def\kaon    {{\ensuremath{\PK}}\xspace}
+%%% do NOT use ensuremath here
+  \def\Kbar    {{\kern 0.2em\overline{\kern -0.2em \PK}{}}\xspace}
+\def\Kb      {{\ensuremath{\Kbar}}\xspace}
+\def\KorKbar    {\kern 0.18em\optbar{\kern -0.18em K}{}\xspace}
+\def\Kz      {{\ensuremath{\kaon^0}}\xspace}
+\def\Kzb     {{\ensuremath{\Kbar{}^0}}\xspace}
+\def\Kp      {{\ensuremath{\kaon^+}}\xspace}
+\def\Km      {{\ensuremath{\kaon^-}}\xspace}
+\def\Kpm     {{\ensuremath{\kaon^\pm}}\xspace}
+\def\Kmp     {{\ensuremath{\kaon^\mp}}\xspace}
+\def\KS      {{\ensuremath{\kaon^0_{\rm\scriptscriptstyle S}}}\xspace}
+\def\KL      {{\ensuremath{\kaon^0_{\rm\scriptscriptstyle L}}}\xspace}
+\def\Kstarz  {{\ensuremath{\kaon^{*0}}}\xspace}
+\def\Kstarzb {{\ensuremath{\Kbar{}^{*0}}}\xspace}
+\def\Kstar   {{\ensuremath{\kaon^*}}\xspace}
+\def\Kstarb  {{\ensuremath{\Kbar{}^*}}\xspace}
+\def\Kstarp  {{\ensuremath{\kaon^{*+}}}\xspace}
+\def\Kstarm  {{\ensuremath{\kaon^{*-}}}\xspace}
+\def\Kstarpm {{\ensuremath{\kaon^{*\pm}}}\xspace}
+\def\Kstarmp {{\ensuremath{\kaon^{*\mp}}}\xspace}
+
+\newcommand{\etaz}{\ensuremath{\Peta}\xspace}
+\newcommand{\etapr}{\ensuremath{\Peta^{\prime}}\xspace}
+\newcommand{\phiz}{\ensuremath{\Pphi}\xspace}
+\newcommand{\omegaz}{\ensuremath{\Pomega}\xspace}
+
+%% Heavy mesons
+
+%%% do NOT use ensuremath here
+  \def\Dbar    {{\kern 0.2em\overline{\kern -0.2em \PD}{}}\xspace}
+\def\D       {{\ensuremath{\PD}}\xspace}
+\def\Db      {{\ensuremath{\Dbar}}\xspace}
+\def\DorDbar    {\kern 0.18em\optbar{\kern -0.18em D}{}\xspace}
+\def\Dz      {{\ensuremath{\D^0}}\xspace}
+\def\Dzb     {{\ensuremath{\Dbar{}^0}}\xspace}
+\def\Dp      {{\ensuremath{\D^+}}\xspace}
+\def\Dm      {{\ensuremath{\D^-}}\xspace}
+\def\Dpm     {{\ensuremath{\D^\pm}}\xspace}
+\def\Dmp     {{\ensuremath{\D^\mp}}\xspace}
+\def\Dstar   {{\ensuremath{\D^*}}\xspace}
+\def\Dstarb  {{\ensuremath{\Dbar{}^*}}\xspace}
+\def\Dstarz  {{\ensuremath{\D^{*0}}}\xspace}
+\def\Dstarzb {{\ensuremath{\Dbar{}^{*0}}}\xspace}
+\def\Dstarp  {{\ensuremath{\D^{*+}}}\xspace}
+\def\Dstarm  {{\ensuremath{\D^{*-}}}\xspace}
+\def\Dstarpm {{\ensuremath{\D^{*\pm}}}\xspace}
+\def\Dstarmp {{\ensuremath{\D^{*\mp}}}\xspace}
+\def\Ds      {{\ensuremath{\D^+_\squark}}\xspace}
+\def\Dsp     {{\ensuremath{\D^+_\squark}}\xspace}
+\def\Dsm     {{\ensuremath{\D^-_\squark}}\xspace}
+\def\Dspm    {{\ensuremath{\D^{\pm}_\squark}}\xspace}
+\def\Dsmp    {{\ensuremath{\D^{\mp}_\squark}}\xspace}
+\def\Dss     {{\ensuremath{\D^{*+}_\squark}}\xspace}
+\def\Dssp    {{\ensuremath{\D^{*+}_\squark}}\xspace}
+\def\Dssm    {{\ensuremath{\D^{*-}_\squark}}\xspace}
+\def\Dsspm   {{\ensuremath{\D^{*\pm}_\squark}}\xspace}
+\def\Dssmp   {{\ensuremath{\D^{*\mp}_\squark}}\xspace}
+
+\def\B       {{\ensuremath{\PB}}\xspace}
+%%% do NOT use ensuremath here
+\def\Bbar    {{\ensuremath{\kern 0.18em\overline{\kern -0.18em \PB}{}}}\xspace}
+\def\Bb      {{\ensuremath{\Bbar}}\xspace}
+\def\BorBbar    {\kern 0.18em\optbar{\kern -0.18em B}{}\xspace}
+\def\Bz      {{\ensuremath{\B^0}}\xspace}
+\def\Bzb     {{\ensuremath{\Bbar{}^0}}\xspace}
+\def\Bu      {{\ensuremath{\B^+}}\xspace}
+\def\Bub     {{\ensuremath{\B^-}}\xspace}
+\def\Bp      {{\ensuremath{\Bu}}\xspace}
+\def\Bm      {{\ensuremath{\Bub}}\xspace}
+\def\Bpm     {{\ensuremath{\B^\pm}}\xspace}
+\def\Bmp     {{\ensuremath{\B^\mp}}\xspace}
+\def\Bd      {{\ensuremath{\B^0}}\xspace}
+\def\Bs      {{\ensuremath{\B^0_\squark}}\xspace}
+\def\Bsb     {{\ensuremath{\Bbar{}^0_\squark}}\xspace}
+\def\Bdb     {{\ensuremath{\Bbar{}^0}}\xspace}
+\def\Bc      {{\ensuremath{\B_\cquark^+}}\xspace}
+\def\Bcp     {{\ensuremath{\B_\cquark^+}}\xspace}
+\def\Bcm     {{\ensuremath{\B_\cquark^-}}\xspace}
+\def\Bcpm    {{\ensuremath{\B_\cquark^\pm}}\xspace}
+
+%% Onia
+
+\def\jpsi     {{\ensuremath{{\PJ\mskip -3mu/\mskip -2mu\Ppsi\mskip 2mu}}}\xspace}
+\def\psitwos  {{\ensuremath{\Ppsi{(2S)}}}\xspace}
+\def\psiprpr  {{\ensuremath{\Ppsi(3770)}}\xspace}
+\def\etac     {{\ensuremath{\Peta_\cquark}}\xspace}
+\def\chiczero {{\ensuremath{\Pchi_{\cquark 0}}}\xspace}
+\def\chicone  {{\ensuremath{\Pchi_{\cquark 1}}}\xspace}
+\def\chictwo  {{\ensuremath{\Pchi_{\cquark 2}}}\xspace}
+  %\mathchardef\Upsilon="7107
+  \def\Y#1S{\ensuremath{\PUpsilon{(#1S)}}\xspace}% no space before {...}!
+\def\OneS  {{\Y1S}}
+\def\TwoS  {{\Y2S}}
+\def\ThreeS{{\Y3S}}
+\def\FourS {{\Y4S}}
+\def\FiveS {{\Y5S}}
+
+\def\chic  {{\ensuremath{\Pchi_{c}}}\xspace}
+
+%% Baryons
+
+\def\proton      {{\ensuremath{\Pp}}\xspace}
+\def\antiproton  {{\ensuremath{\overline \proton}}\xspace}
+\def\neutron     {{\ensuremath{\Pn}}\xspace}
+\def\antineutron {{\ensuremath{\overline \neutron}}\xspace}
+\def\Deltares    {{\ensuremath{\PDelta}}\xspace}
+\def\Deltaresbar {{\ensuremath{\overline \Deltares}}\xspace}
+\def\Xires       {{\ensuremath{\PXi}}\xspace}
+\def\Xiresbar    {{\ensuremath{\overline \Xires}}\xspace}
+\def\Lz          {{\ensuremath{\PLambda}}\xspace}
+\def\Lbar        {{\ensuremath{\kern 0.1em\overline{\kern -0.1em\PLambda}}}\xspace}
+\def\LorLbar    {\kern 0.18em\optbar{\kern -0.18em \PLambda}{}\xspace}
+\def\Lambdares   {{\ensuremath{\PLambda}}\xspace}
+\def\Lambdaresbar{{\ensuremath{\Lbar}}\xspace}
+\def\Sigmares    {{\ensuremath{\PSigma}}\xspace}
+\def\Sigmaresbar {{\ensuremath{\overline \Sigmares}}\xspace}
+\def\Omegares    {{\ensuremath{\POmega}}\xspace}
+\def\Omegaresbar {{\ensuremath{\overline \POmega}}\xspace}
+
+%%% do NOT use ensuremath here
+ % \def\Deltabar{\kern 0.25em\overline{\kern -0.25em \Deltares}{}\xspace}
+ % \def\Sigbar{\kern 0.2em\overline{\kern -0.2em \Sigma}{}\xspace}
+ % \def\Xibar{\kern 0.2em\overline{\kern -0.2em \Xi}{}\xspace}
+ % \def\Obar{\kern 0.2em\overline{\kern -0.2em \Omega}{}\xspace}
+ % \def\Nbar{\kern 0.2em\overline{\kern -0.2em N}{}\xspace}
+ % \def\Xb{\kern 0.2em\overline{\kern -0.2em X}{}\xspace}
+
+\def\Lb      {{\ensuremath{\Lz^0_\bquark}}\xspace}
+\def\Lbbar   {{\ensuremath{\Lbar{}^0_\bquark}}\xspace}
+\def\Lc      {{\ensuremath{\Lz^+_\cquark}}\xspace}
+\def\Lcbar   {{\ensuremath{\Lbar{}^-_\cquark}}\xspace}
+\def\Xibz    {{\ensuremath{\Xires^0_\bquark}}\xspace}
+\def\Xibm    {{\ensuremath{\Xires^-_\bquark}}\xspace}
+\def\Xibbarz {{\ensuremath{\Xiresbar{}_\bquark^0}}\xspace}
+\def\Xibbarp {{\ensuremath{\Xiresbar{}_\bquark^+}}\xspace}
+\def\Xicz    {{\ensuremath{\Xires^0_\cquark}}\xspace}
+\def\Xicp    {{\ensuremath{\Xires^+_\cquark}}\xspace}
+\def\Xicbarz {{\ensuremath{\Xiresbar{}_\cquark^0}}\xspace}
+\def\Xicbarm {{\ensuremath{\Xiresbar{}_\cquark^-}}\xspace}
+\def\Omegac    {{\ensuremath{\Omegares^0_\cquark}}\xspace}
+\def\Omegacbar {{\ensuremath{\Omegaresbar{}_\cquark^0}}\xspace}
+\def\Omegab    {{\ensuremath{\Omegares^-_\bquark}}\xspace}
+\def\Omegabbar {{\ensuremath{\Omegaresbar{}_\bquark^+}}\xspace}
+
+%%%%%%%%%%%%%%%%%%
+% Physics symbols
+%%%%%%%%%%%%%%%%%
+
+%% Decays
+\def\BF         {{\ensuremath{\cal B}}\xspace}
+\def\BRvis      {{\ensuremath{\BR_{\rm{vis}}}}}
+\def\BR         {\BF}
+\newcommand{\decay}[2]{\ensuremath{#1\!\to #2}\xspace}         % {\Pa}{\Pb \Pc}
+\def\ra                 {\ensuremath{\rightarrow}\xspace}
+\def\to                 {\ensuremath{\rightarrow}\xspace}
+
+%% Lifetimes
+\newcommand{\tauBs}{{\ensuremath{\tau_{\Bs}}}\xspace}
+\newcommand{\tauBd}{{\ensuremath{\tau_{\Bd}}}\xspace}
+\newcommand{\tauBz}{{\ensuremath{\tau_{\Bz}}}\xspace}
+\newcommand{\tauBu}{{\ensuremath{\tau_{\Bp}}}\xspace}
+\newcommand{\tauDp}{{\ensuremath{\tau_{\Dp}}}\xspace}
+\newcommand{\tauDz}{{\ensuremath{\tau_{\Dz}}}\xspace}
+\newcommand{\tauL}{{\ensuremath{\tau_{\rm L}}}\xspace}
+\newcommand{\tauH}{{\ensuremath{\tau_{\rm H}}}\xspace}
+
+%% Masses
+\newcommand{\mBd}{{\ensuremath{m_{\Bd}}}\xspace}
+\newcommand{\mBp}{{\ensuremath{m_{\Bp}}}\xspace}
+\newcommand{\mBs}{{\ensuremath{m_{\Bs}}}\xspace}
+\newcommand{\mBc}{{\ensuremath{m_{\Bc}}}\xspace}
+\newcommand{\mLb}{{\ensuremath{m_{\Lb}}}\xspace}
+
+%% EW theory, groups
+\def\grpsuthree {{\ensuremath{\mathrm{SU}(3)}}\xspace}
+\def\grpsutw    {{\ensuremath{\mathrm{SU}(2)}}\xspace}
+\def\grpuone    {{\ensuremath{\mathrm{U}(1)}}\xspace}
+
+\def\ssqtw   {{\ensuremath{\sin^{2}\!\theta_{\mathrm{W}}}}\xspace}
+\def\csqtw   {{\ensuremath{\cos^{2}\!\theta_{\mathrm{W}}}}\xspace}
+\def\stw     {{\ensuremath{\sin\theta_{\mathrm{W}}}}\xspace}
+\def\ctw     {{\ensuremath{\cos\theta_{\mathrm{W}}}}\xspace}
+\def\ssqtwef {{\ensuremath{{\sin}^{2}\theta_{\mathrm{W}}^{\mathrm{eff}}}}\xspace}
+\def\csqtwef {{\ensuremath{{\cos}^{2}\theta_{\mathrm{W}}^{\mathrm{eff}}}}\xspace}
+\def\stwef   {{\ensuremath{\sin\theta_{\mathrm{W}}^{\mathrm{eff}}}}\xspace}
+\def\ctwef   {{\ensuremath{\cos\theta_{\mathrm{W}}^{\mathrm{eff}}}}\xspace}
+\def\gv      {{\ensuremath{g_{\mbox{\tiny V}}}}\xspace}
+\def\ga      {{\ensuremath{g_{\mbox{\tiny A}}}}\xspace}
+
+\def\order   {{\ensuremath{\mathcal{O}}}\xspace}
+\def\ordalph {{\ensuremath{\mathcal{O}(\alpha)}}\xspace}
+\def\ordalsq {{\ensuremath{\mathcal{O}(\alpha^{2})}}\xspace}
+\def\ordalcb {{\ensuremath{\mathcal{O}(\alpha^{3})}}\xspace}
+
+%% QCD parameters
+\newcommand{\as}{{\ensuremath{\alpha_s}}\xspace}
+\newcommand{\MSb}{{\ensuremath{\overline{\mathrm{MS}}}}\xspace}
+\newcommand{\lqcd}{{\ensuremath{\Lambda_{\mathrm{QCD}}}}\xspace}
+\def\qsq       {{\ensuremath{q^2}}\xspace}
+
+%% CKM, CP violation
+
+\def\eps   {{\ensuremath{\varepsilon}}\xspace}
+\def\epsK  {{\ensuremath{\varepsilon_K}}\xspace}
+\def\epsB  {{\ensuremath{\varepsilon_B}}\xspace}
+\def\epsp  {{\ensuremath{\varepsilon^\prime_K}}\xspace}
+
+\def\CP                {{\ensuremath{C\!P}}\xspace}
+\def\CPT               {{\ensuremath{C\!PT}}\xspace}
+
+\def\rhobar {{\ensuremath{\overline \rho}}\xspace}
+\def\etabar {{\ensuremath{\overline \eta}}\xspace}
+
+\def\Vud  {{\ensuremath{V_{\uquark\dquark}}}\xspace}
+\def\Vcd  {{\ensuremath{V_{\cquark\dquark}}}\xspace}
+\def\Vtd  {{\ensuremath{V_{\tquark\dquark}}}\xspace}
+\def\Vus  {{\ensuremath{V_{\uquark\squark}}}\xspace}
+\def\Vcs  {{\ensuremath{V_{\cquark\squark}}}\xspace}
+\def\Vts  {{\ensuremath{V_{\tquark\squark}}}\xspace}
+\def\Vub  {{\ensuremath{V_{\uquark\bquark}}}\xspace}
+\def\Vcb  {{\ensuremath{V_{\cquark\bquark}}}\xspace}
+\def\Vtb  {{\ensuremath{V_{\tquark\bquark}}}\xspace}
+
+%% Oscillations
+
+\newcommand{\dm}{{\ensuremath{\Delta m}}\xspace}
+\newcommand{\dms}{{\ensuremath{\Delta m_{\squark}}}\xspace}
+\newcommand{\dmd}{{\ensuremath{\Delta m_{\dquark}}}\xspace}
+\newcommand{\DG}{{\ensuremath{\Delta\Gamma}}\xspace}
+\newcommand{\DGs}{{\ensuremath{\Delta\Gamma_{\squark}}}\xspace}
+\newcommand{\DGd}{{\ensuremath{\Delta\Gamma_{\dquark}}}\xspace}
+\newcommand{\Gs}{{\ensuremath{\Gamma_{\squark}}}\xspace}
+\newcommand{\Gd}{{\ensuremath{\Gamma_{\dquark}}}\xspace}
+\newcommand{\MBq}{{\ensuremath{M_{\B_\quark}}}\xspace}
+\newcommand{\DGq}{{\ensuremath{\Delta\Gamma_{\quark}}}\xspace}
+\newcommand{\Gq}{{\ensuremath{\Gamma_{\quark}}}\xspace}
+\newcommand{\dmq}{{\ensuremath{\Delta m_{\quark}}}\xspace}
+\newcommand{\GL}{{\ensuremath{\Gamma_{\rm L}}}\xspace}
+\newcommand{\GH}{{\ensuremath{\Gamma_{\rm H}}}\xspace}
+\newcommand{\DGsGs}{{\ensuremath{\Delta\Gamma_{\squark}/\Gamma_{\squark}}}\xspace}
+\newcommand{\Delm}{{\mbox{$\Delta m $}}\xspace}
+\newcommand{\ACP}{{\ensuremath{{\cal A}^{\CP}}}\xspace}
+\newcommand{\Adir}{{\ensuremath{{\cal A}^{\rm dir}}}\xspace}
+\newcommand{\Amix}{{\ensuremath{{\cal A}^{\rm mix}}}\xspace}
+\newcommand{\ADelta}{{\ensuremath{{\cal A}^\Delta}}\xspace}
+\newcommand{\phid}{{\ensuremath{\phi_{\dquark}}}\xspace}
+\newcommand{\sinphid}{{\ensuremath{\sin\!\phid}}\xspace}
+\newcommand{\phis}{{\ensuremath{\phi_{\squark}}}\xspace}
+\newcommand{\betas}{{\ensuremath{\beta_{\squark}}}\xspace}
+\newcommand{\sbetas}{{\ensuremath{\sigma(\beta_{\squark})}}\xspace}
+\newcommand{\stbetas}{{\ensuremath{\sigma(2\beta_{\squark})}}\xspace}
+\newcommand{\stphis}{{\ensuremath{\sigma(\phi_{\squark})}}\xspace}
+\newcommand{\sinphis}{{\ensuremath{\sin\!\phis}}\xspace}
+
+%% Tagging
+\newcommand{\edet}{{\ensuremath{\varepsilon_{\rm det}}}\xspace}
+\newcommand{\erec}{{\ensuremath{\varepsilon_{\rm rec/det}}}\xspace}
+\newcommand{\esel}{{\ensuremath{\varepsilon_{\rm sel/rec}}}\xspace}
+\newcommand{\etrg}{{\ensuremath{\varepsilon_{\rm trg/sel}}}\xspace}
+\newcommand{\etot}{{\ensuremath{\varepsilon_{\rm tot}}}\xspace}
+
+\newcommand{\mistag}{\ensuremath{\omega}\xspace}
+\newcommand{\wcomb}{\ensuremath{\omega^{\rm comb}}\xspace}
+\newcommand{\etag}{{\ensuremath{\varepsilon_{\rm tag}}}\xspace}
+\newcommand{\etagcomb}{{\ensuremath{\varepsilon_{\rm tag}^{\rm comb}}}\xspace}
+\newcommand{\effeff}{\ensuremath{\varepsilon_{\rm eff}}\xspace}
+\newcommand{\effeffcomb}{\ensuremath{\varepsilon_{\rm eff}^{\rm comb}}\xspace}
+\newcommand{\efftag}{{\ensuremath{\etag(1-2\omega)^2}}\xspace}
+\newcommand{\effD}{{\ensuremath{\etag D^2}}\xspace}
+
+\newcommand{\etagprompt}{{\ensuremath{\varepsilon_{\rm tag}^{\rm Pr}}}\xspace}
+\newcommand{\etagLL}{{\ensuremath{\varepsilon_{\rm tag}^{\rm LL}}}\xspace}
+
+%% Key decay channels
+
+\def\BdToKstmm    {\decay{\Bd}{\Kstarz\mup\mun}}
+\def\BdbToKstmm   {\decay{\Bdb}{\Kstarzb\mup\mun}}
+
+\def\BsToJPsiPhi  {\decay{\Bs}{\jpsi\phi}}
+\def\BdToJPsiKst  {\decay{\Bd}{\jpsi\Kstarz}}
+\def\BdbToJPsiKst {\decay{\Bdb}{\jpsi\Kstarzb}}
+
+\def\BsPhiGam     {\decay{\Bs}{\phi \g}}
+\def\BdKstGam     {\decay{\Bd}{\Kstarz \g}}
+
+\def\BTohh        {\decay{\B}{\Ph^+ \Ph'^-}}
+\def\BdTopipi     {\decay{\Bd}{\pip\pim}}
+\def\BdToKpi      {\decay{\Bd}{\Kp\pim}}
+\def\BsToKK       {\decay{\Bs}{\Kp\Km}}
+\def\BsTopiK      {\decay{\Bs}{\pip\Km}}
+
+%% Rare decays
+\def\BdKstee  {\decay{\Bd}{\Kstarz\epem}}
+\def\BdbKstee {\decay{\Bdb}{\Kstarzb\epem}}
+\def\bsll     {\decay{\bquark}{\squark \ell^+ \ell^-}}
+\def\AFB      {\ensuremath{A_{\mathrm{FB}}}\xspace}
+\def\FL       {\ensuremath{F_{\mathrm{L}}}\xspace}
+\def\AT#1     {\ensuremath{A_{\mathrm{T}}^{#1}}\xspace}           % 2
+\def\btosgam  {\decay{\bquark}{\squark \g}}
+\def\btodgam  {\decay{\bquark}{\dquark \g}}
+\def\Bsmm     {\decay{\Bs}{\mup\mun}}
+\def\Bdmm     {\decay{\Bd}{\mup\mun}}
+\def\ctl       {\ensuremath{\cos{\theta_\ell}}\xspace}
+\def\ctk       {\ensuremath{\cos{\theta_K}}\xspace}
+
+%% Wilson coefficients and operators
+\def\C#1      {\ensuremath{\mathcal{C}_{#1}}\xspace}                       % 9
+\def\Cp#1     {\ensuremath{\mathcal{C}_{#1}^{'}}\xspace}                    % 7
+\def\Ceff#1   {\ensuremath{\mathcal{C}_{#1}^{\mathrm{(eff)}}}\xspace}        % 9  
+\def\Cpeff#1  {\ensuremath{\mathcal{C}_{#1}^{'\mathrm{(eff)}}}\xspace}       % 7
+\def\Ope#1    {\ensuremath{\mathcal{O}_{#1}}\xspace}                       % 2
+\def\Opep#1   {\ensuremath{\mathcal{O}_{#1}^{'}}\xspace}                    % 7
+
+%% Charm
+
+\def\xprime     {\ensuremath{x^{\prime}}\xspace}
+\def\yprime     {\ensuremath{y^{\prime}}\xspace}
+\def\ycp        {\ensuremath{y_{\CP}}\xspace}
+\def\agamma     {\ensuremath{A_{\Gamma}}\xspace}
+%%%\def\kpi        {\ensuremath{\PK\Ppi}\xspace}
+%%%\def\kk         {\ensuremath{\PK\PK}\xspace}
+%%%\def\dkpi       {\decay{\PD}{\PK\Ppi}}
+%%%\def\dkk        {\decay{\PD}{\PK\PK}}
+\def\dkpicf     {\decay{\Dz}{\Km\pip}}
+
+%% QM
+\newcommand{\bra}[1]{\ensuremath{\langle #1|}}             % {a}
+\newcommand{\ket}[1]{\ensuremath{|#1\rangle}}              % {b}
+\newcommand{\braket}[2]{\ensuremath{\langle #1|#2\rangle}} % {a}{b}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Units
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newcommand{\unit}[1]{\ensuremath{\rm\,#1}\xspace}          % {kg}
+
+%% Energy and momentum
+\newcommand{\tev}{\ifthenelse{\boolean{inbibliography}}{\ensuremath{~T\kern -0.05em eV}\xspace}{\ensuremath{\mathrm{\,Te\kern -0.1em V}}}\xspace}
+\newcommand{\gev}{\ensuremath{\mathrm{\,Ge\kern -0.1em V}}\xspace}
+\newcommand{\mev}{\ensuremath{\mathrm{\,Me\kern -0.1em V}}\xspace}
+\newcommand{\kev}{\ensuremath{\mathrm{\,ke\kern -0.1em V}}\xspace}
+\newcommand{\ev}{\ensuremath{\mathrm{\,e\kern -0.1em V}}\xspace}
+\newcommand{\gevc}{\ensuremath{{\mathrm{\,Ge\kern -0.1em V\!/}c}}\xspace}
+\newcommand{\mevc}{\ensuremath{{\mathrm{\,Me\kern -0.1em V\!/}c}}\xspace}
+\newcommand{\gevcc}{\ensuremath{{\mathrm{\,Ge\kern -0.1em V\!/}c^2}}\xspace}
+\newcommand{\gevgevcccc}{\ensuremath{{\mathrm{\,Ge\kern -0.1em V^2\!/}c^4}}\xspace}
+\newcommand{\mevcc}{\ensuremath{{\mathrm{\,Me\kern -0.1em V\!/}c^2}}\xspace}
+
+%% Distance and area
+\def\km   {\ensuremath{\rm \,km}\xspace}
+\def\m    {\ensuremath{\rm \,m}\xspace}
+\def\ma   {\ensuremath{{\rm \,m}^2}\xspace}
+\def\cm   {\ensuremath{\rm \,cm}\xspace}
+\def\cma  {\ensuremath{{\rm \,cm}^2}\xspace}
+\def\mm   {\ensuremath{\rm \,mm}\xspace}
+\def\mma  {\ensuremath{{\rm \,mm}^2}\xspace}
+\def\mum  {\ensuremath{{\,\upmu\rm m}}\xspace}
+\def\muma {\ensuremath{{\,\upmu\rm m^2}}\xspace}
+\def\nm   {\ensuremath{\rm \,nm}\xspace}
+\def\fm   {\ensuremath{\rm \,fm}\xspace}
+\def\barn{\ensuremath{\rm \,b}\xspace}
+%%%\def\barnhyph{\ensuremath{\rm -b}\xspace}
+\def\mbarn{\ensuremath{\rm \,mb}\xspace}
+\def\mub{\ensuremath{{\rm \,\upmu b}}\xspace}
+%%%\def\mbarnhyph{\ensuremath{\rm -mb}\xspace}
+\def\nb {\ensuremath{\rm \,nb}\xspace}
+\def\invnb {\ensuremath{\mbox{\,nb}^{-1}}\xspace}
+\def\pb {\ensuremath{\rm \,pb}\xspace}
+\def\invpb {\ensuremath{\mbox{\,pb}^{-1}}\xspace}
+\def\fb   {\ensuremath{\mbox{\,fb}}\xspace}
+\def\invfb   {\ensuremath{\mbox{\,fb}^{-1}}\xspace}
+
+%% Time 
+\def\sec  {\ensuremath{\rm {\,s}}\xspace}
+\def\ms   {\ensuremath{{\rm \,ms}}\xspace}
+\def\mus  {\ensuremath{{\,\upmu{\rm s}}}\xspace}
+\def\ns   {\ensuremath{{\rm \,ns}}\xspace}
+\def\ps   {\ensuremath{{\rm \,ps}}\xspace}
+\def\fs   {\ensuremath{\rm \,fs}\xspace}
+
+\def\mhz  {\ensuremath{{\rm \,MHz}}\xspace}
+\def\khz  {\ensuremath{{\rm \,kHz}}\xspace}
+\def\hz   {\ensuremath{{\rm \,Hz}}\xspace}
+
+\def\invps{\ensuremath{{\rm \,ps^{-1}}}\xspace}
+
+\def\yr   {\ensuremath{\rm \,yr}\xspace}
+\def\hr   {\ensuremath{\rm \,hr}\xspace}
+
+%% Temperature
+\def\degc {\ensuremath{^\circ}{C}\xspace}
+\def\degk {\ensuremath {\rm K}\xspace}
+
+%% Material lengths, radiation
+\def\Xrad {\ensuremath{X_0}\xspace}
+\def\NIL{\ensuremath{\lambda_{int}}\xspace}
+\def\mip {MIP\xspace}
+\def\neutroneq {\ensuremath{\rm \,n_{eq}}\xspace}
+\def\neqcmcm {\ensuremath{\rm \,n_{eq} / cm^2}\xspace}
+\def\kRad {\ensuremath{\rm \,kRad}\xspace}
+\def\MRad {\ensuremath{\rm \,MRad}\xspace}
+\def\ci {\ensuremath{\rm \,Ci}\xspace}
+\def\mci {\ensuremath{\rm \,mCi}\xspace}
+
+%% Uncertainties
+\def\sx    {\ensuremath{\sigma_x}\xspace}    
+\def\sy    {\ensuremath{\sigma_y}\xspace}   
+\def\sz    {\ensuremath{\sigma_z}\xspace}    
+
+\newcommand{\stat}{\ensuremath{\mathrm{\,(stat)}}\xspace}
+\newcommand{\syst}{\ensuremath{\mathrm{\,(syst)}}\xspace}
+
+%% Maths
+
+\def\order{{\ensuremath{\cal O}}\xspace}
+\newcommand{\chisq}{\ensuremath{\chi^2}\xspace}
+\newcommand{\chisqndf}{\ensuremath{\chi^2/\mathrm{ndf}}\xspace}
+\newcommand{\chisqip}{\ensuremath{\chi^2_{\rm IP}}\xspace}
+\newcommand{\chisqvs}{\ensuremath{\chi^2_{\rm VS}}\xspace}
+\newcommand{\chisqvtx}{\ensuremath{\chi^2_{\rm vtx}}\xspace}
+
+\def\deriv {\ensuremath{\mathrm{d}}}
+
+\def\gsim{{~\raise.15em\hbox{$>$}\kern-.85em
+          \lower.35em\hbox{$\sim$}~}\xspace}
+\def\lsim{{~\raise.15em\hbox{$<$}\kern-.85em
+          \lower.35em\hbox{$\sim$}~}\xspace}
+
+\newcommand{\mean}[1]{\ensuremath{\left\langle #1 \right\rangle}} % {x}
+\newcommand{\abs}[1]{\ensuremath{\left\|#1\right\|}} % {x}
+\newcommand{\Real}{\ensuremath{\mathcal{R}e}\xspace}
+\newcommand{\Imag}{\ensuremath{\mathcal{I}m}\xspace}
+
+\def\PDF {PDF\xspace}
+
+\def\sPlot{\mbox{\em sPlot}\xspace}
+%%%\def\sWeight{\mbox{\em sWeight}\xspace}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Kinematics
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Energy, Momenta
+\def\Ebeam {\ensuremath{E_{\mbox{\tiny BEAM}}}\xspace}
+\def\sqs   {\ensuremath{\protect\sqrt{s}}\xspace}
+
+\def\ptot       {\mbox{$p$}\xspace}
+\def\pt         {\mbox{$p_{\rm T}$}\xspace}
+\def\et         {\mbox{$E_{\rm T}$}\xspace}
+\def\mt         {\mbox{$M_{\rm T}$}\xspace}
+\def\dpp        {\ensuremath{\Delta p/p}\xspace}
+\def\msq        {\ensuremath{m^2}\xspace}
+\newcommand{\dedx}{\ensuremath{\mathrm{d}\hspace{-0.1em}E/\mathrm{d}x}\xspace}
+
+%% PID
+
+\def\dllkpi     {\ensuremath{\mathrm{DLL}_{\kaon\pion}}\xspace}
+\def\dllppi     {\ensuremath{\mathrm{DLL}_{\proton\pion}}\xspace}
+\def\dllepi     {\ensuremath{\mathrm{DLL}_{\electron\pion}}\xspace}
+\def\dllmupi    {\ensuremath{\mathrm{DLL}_{\muon\pi}}\xspace}
+
+%% Geometry
+%%%\def\mphi       {\mbox{$\phi$}\xspace}
+%%%\def\mtheta     {\mbox{$\theta$}\xspace}
+%%%\def\ctheta     {\mbox{$\cos\theta$}\xspace}
+%%%\def\stheta     {\mbox{$\sin\theta$}\xspace}
+%%%\def\ttheta     {\mbox{$\tan\theta$}\xspace}
+
+\def\degrees{\ensuremath{^{\circ}}\xspace}
+\def\krad {\ensuremath{\rm \,krad}\xspace}
+\def\mrad{\ensuremath{\rm \,mrad}\xspace}
+\def\rad{\ensuremath{\rm \,rad}\xspace}
+
+%% Accelerator
+\def\betastar {\ensuremath{\beta^*}}
+\newcommand{\lum} {\ensuremath{\mathcal{L}}\xspace}
+\newcommand{\intlum}[1]{\ensuremath{\int\lum=#1}\xspace}  % {2 \,\invfb}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Software
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Programs
+%%%\def\ansys      {\mbox{\textsc{Ansys}}\xspace}
+\def\bcvegpy    {\mbox{\textsc{Bcvegpy}}\xspace}
+\def\boole      {\mbox{\textsc{Boole}}\xspace}
+\def\brunel     {\mbox{\textsc{Brunel}}\xspace}
+\def\davinci    {\mbox{\textsc{DaVinci}}\xspace}
+\def\dirac      {\mbox{\textsc{Dirac}}\xspace}
+%%%\def\erasmus    {\mbox{\textsc{Erasmus}}\xspace}
+\def\evtgen     {\mbox{\textsc{EvtGen}}\xspace}
+\def\fewz       {\mbox{\textsc{Fewz}}\xspace}
+\def\fluka      {\mbox{\textsc{Fluka}}\xspace}
+\def\ganga      {\mbox{\textsc{Ganga}}\xspace}
+%%%\def\garfield   {\mbox{\textsc{Garfield}}\xspace}
+\def\gaudi      {\mbox{\textsc{Gaudi}}\xspace}
+\def\gauss      {\mbox{\textsc{Gauss}}\xspace}
+\def\geant      {\mbox{\textsc{Geant4}}\xspace}
+\def\hepmc      {\mbox{\textsc{HepMC}}\xspace}
+\def\herwig     {\mbox{\textsc{Herwig}}\xspace}
+\def\moore      {\mbox{\textsc{Moore}}\xspace}
+\def\neurobayes {\mbox{\textsc{NeuroBayes}}\xspace}
+\def\photos     {\mbox{\textsc{Photos}}\xspace}
+\def\powheg     {\mbox{\textsc{Powheg}}\xspace}
+%%%\def\pyroot     {\mbox{\textsc{PyRoot}}\xspace}
+\def\pythia     {\mbox{\textsc{Pythia}}\xspace}
+\def\resbos     {\mbox{\textsc{ResBos}}\xspace}
+\def\roofit     {\mbox{\textsc{RooFit}}\xspace}
+\def\root       {\mbox{\textsc{Root}}\xspace}
+\def\spice      {\mbox{\textsc{Spice}}\xspace}
+%%%\def\tosca      {\mbox{\textsc{Tosca}}\xspace}
+\def\urania     {\mbox{\textsc{Urania}}\xspace}
+
+%% Languages
+\def\cpp        {\mbox{\textsc{C\raisebox{0.1em}{{\footnotesize{++}}}}}\xspace}
+%%%\def\python     {\mbox{\textsc{Python}}\xspace}
+\def\ruby       {\mbox{\textsc{Ruby}}\xspace}
+\def\fortran    {\mbox{\textsc{Fortran}}\xspace}
+\def\svn        {\mbox{\textsc{SVN}}\xspace}
+
+%% Data processing
+\def\kbytes     {\ensuremath{{\rm \,kbytes}}\xspace}
+\def\kbsps      {\ensuremath{{\rm \,kbytes/s}}\xspace}
+\def\kbits      {\ensuremath{{\rm \,kbits}}\xspace}
+\def\kbsps      {\ensuremath{{\rm \,kbits/s}}\xspace}
+\def\mbsps      {\ensuremath{{\rm \,Mbits/s}}\xspace}
+\def\mbytes     {\ensuremath{{\rm \,Mbytes}}\xspace}
+\def\mbps       {\ensuremath{{\rm \,Mbyte/s}}\xspace}
+\def\mbsps      {\ensuremath{{\rm \,Mbytes/s}}\xspace}
+\def\gbsps      {\ensuremath{{\rm \,Gbits/s}}\xspace}
+\def\gbytes     {\ensuremath{{\rm \,Gbytes}}\xspace}
+\def\gbsps      {\ensuremath{{\rm \,Gbytes/s}}\xspace}
+\def\tbytes     {\ensuremath{{\rm \,Tbytes}}\xspace}
+\def\tbpy       {\ensuremath{{\rm \,Tbytes/yr}}\xspace}
+
+\def\dst        {DST\xspace}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Detector related
+%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% Detector technologies
+\def\nonn {\ensuremath{\rm {\it{n^+}}\mbox{-}on\mbox{-}{\it{n}}}\xspace}
+\def\ponn {\ensuremath{\rm {\it{p^+}}\mbox{-}on\mbox{-}{\it{n}}}\xspace}
+\def\nonp {\ensuremath{\rm {\it{n^+}}\mbox{-}on\mbox{-}{\it{p}}}\xspace}
+\def\cvd  {CVD\xspace}
+\def\mwpc {MWPC\xspace}
+\def\gem  {GEM\xspace}
+
+%% Detector components, electronics
+\def\tell1  {TELL1\xspace}
+\def\ukl1   {UKL1\xspace}
+\def\beetle {Beetle\xspace}
+\def\otis   {OTIS\xspace}
+\def\croc   {CROC\xspace}
+\def\carioca {CARIOCA\xspace}
+\def\dialog {DIALOG\xspace}
+\def\sync   {SYNC\xspace}
+\def\cardiac {CARDIAC\xspace}
+\def\gol    {GOL\xspace}
+\def\vcsel  {VCSEL\xspace}
+\def\ttc    {TTC\xspace}
+\def\ttcrx  {TTCrx\xspace}
+\def\hpd    {HPD\xspace}
+\def\pmt    {PMT\xspace}
+\def\specs  {SPECS\xspace}
+\def\elmb   {ELMB\xspace}
+\def\fpga   {FPGA\xspace}
+\def\plc    {PLC\xspace}
+\def\rasnik {RASNIK\xspace}
+\def\elmb   {ELMB\xspace}
+\def\can    {CAN\xspace}
+\def\lvds   {LVDS\xspace}
+\def\ntc    {NTC\xspace}
+\def\adc    {ADC\xspace}
+\def\led    {LED\xspace}
+\def\ccd    {CCD\xspace}
+\def\hv     {HV\xspace}
+\def\lv     {LV\xspace}
+\def\pvss   {PVSS\xspace}
+\def\cmos   {CMOS\xspace}
+\def\fifo   {FIFO\xspace}
+\def\ccpc   {CCPC\xspace}
+
+%% Chemical symbols
+\def\cfourften     {\ensuremath{\rm C_4 F_{10}}\xspace}
+\def\cffour        {\ensuremath{\rm CF_4}\xspace}
+\def\cotwo         {\ensuremath{\rm CO_2}\xspace} 
+\def\csixffouteen  {\ensuremath{\rm C_6 F_{14}}\xspace} 
+\def\mgftwo     {\ensuremath{\rm Mg F_2}\xspace} 
+\def\siotwo     {\ensuremath{\rm SiO_2}\xspace} 
+
+%%%%%%%%%%%%%%%
+% Special Text 
+%%%%%%%%%%%%%%%
+\newcommand{\eg}{\mbox{\itshape e.g.}\xspace}
+\newcommand{\ie}{\mbox{\itshape i.e.}\xspace}
+\newcommand{\etal}{\mbox{\itshape et al.}\xspace}
+\newcommand{\etc}{\mbox{\itshape etc.}\xspace}
+%\newcommand{\cf}{\mbox{\itshape cf.}\xspace} % For some reason, the GDR proposal doesn't like this line.
+\newcommand{\ffp}{\mbox{\itshape ff.}\xspace}
+\newcommand{\vs}{\mbox{\itshape vs.}\xspace}


### PR DESCRIPTION
Include almost-standard version of lhcb-symbols-def.tex so that we can all use \pip to our hearts' content.
